### PR TITLE
Add MQTT discovery message for Home Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Add support for Home Assistant discovery (@lbossle)
+
 ## 0.6.3
 
 * Fix bug with scanning unnamed devices for WinRT bluetooth backend

--- a/bluetti_mqtt/logger_cli.py
+++ b/bluetti_mqtt/logger_cli.py
@@ -7,6 +7,7 @@ import json
 import re
 import textwrap
 import time
+import sys
 from bleak import BleakScanner
 from bluetti_mqtt.bluetooth import scan_devices
 from bluetti_mqtt.bluetooth.client import BluetoothClient
@@ -110,3 +111,6 @@ def main():
         asyncio.run(log(args.address, args.log))
     else:
         parser.print_help()
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -120,8 +120,10 @@ class MQTTClient:
 
         
         def payload(id: str, device: BluettiDevice, **kwargs) -> str:
+            # Unknown keys are allowed but ignored by Home Assistant
             payload_dict = {
                 'state_topic': f'bluetti/state/{device.type}-{device.sn}/{id}',
+                'command_topic': f'bluetti/command/{device.type}-{device.sn}/{id}',
                 'device': {
                     'identifiers': [
                         f'{device.sn}'
@@ -131,6 +133,7 @@ class MQTTClient:
                     'model': device.type
                 },
                 'unique_id': f'{device.sn}_{id}',
+                'object_id': f'{device.type}_{id}',
             }
 
             for key, value in kwargs.items():
@@ -204,22 +207,22 @@ class MQTTClient:
                         retain=True
                         )
 
-            await client.publish(f'homeassistant/binary_sensor/{d.sn}_ac_output_on/config',
+            await client.publish(f'homeassistant/switch/{d.sn}_ac_output_on/config',
                         payload=payload(
                             id='ac_output_on',
                             device=d,
                             name='AC Output',
-                            device_class='power')
+                            device_class='outlet')
                             .encode(),
                         retain=True
                         )
 
-            await client.publish(f'homeassistant/binary_sensor/{d.sn}_dc_output_on/config',
+            await client.publish(f'homeassistant/switch/{d.sn}_dc_output_on/config',
                         payload=payload(
                             id='dc_output_on',
                             device=d,
                             name='DC Output',
-                            device_class='power')
+                            device_class='outlet')
                             .encode(),
                         retain=True
                         )

--- a/bluetti_mqtt/server_cli.py
+++ b/bluetti_mqtt/server_cli.py
@@ -121,3 +121,6 @@ def main(argv=None):
 
     cli = CommandLineHandler(argv)
     cli.execute()
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Hey,

I added that when connecting to the MQTT Broker, Home Assistant automatically discovers the bluetti battery as a new device. This is done by sending a special message (see [HA Doc](https://www.home-assistant.io/docs/mqtt/discovery/)). 

Thus far I only added a few sensors (the ones I use in HA). But it should be quite easy to add the rest of the sensors and the commands. Is this something that is in the scope of this project? Looking forward to your feedback.