### PR TITLE
Fix bug with automatic bluetooth reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Home Assistant discovery (@lbossle)
 * Re-architect parsing to support device-specific customization
 * Add beta support for EB3A
+* Fix bug with automatic bluetooth reconnect
 
 ## 0.6.3
 

--- a/bluetti_mqtt/bluetooth/__init__.py
+++ b/bluetti_mqtt/bluetooth/__init__.py
@@ -3,7 +3,7 @@ import logging
 import re
 import time
 from typing import Dict, List, Set
-from bleak import BleakScanner
+from bleak import BleakError, BleakScanner
 from bleak.backends.device import BLEDevice
 from bluetti_mqtt.bus import CommandMessage, EventBus, ParserMessage
 from bluetti_mqtt.commands import QueryRangeCommand
@@ -71,7 +71,7 @@ class BluetoothClientHandler:
             await self.bus.put(ParserMessage(device, parsed))
         except ParseError:
             logging.debug('Got a parse exception...')
-        except BadConnectionError as err:
+        except (BadConnectionError, BleakError) as err:
             logging.debug(f'Needed to disconnect due to error: {err}')
 
 


### PR DESCRIPTION
The `BluetoothClient.perform` API call forwards the `BleakError` exception to callers, but that exception was not being handled by the polling loop. Catching and handling this exception fixes automatic reconnect.