### PR TITLE
Multiple pack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Add support for reporting details for multiple battery packs
+
 ## 0.7.1
 
 * Fix crash with EB3A logging (@jretz)

--- a/bluetti_mqtt/bluetooth/__init__.py
+++ b/bluetti_mqtt/bluetooth/__init__.py
@@ -9,7 +9,7 @@ from bluetti_mqtt.bus import CommandMessage, EventBus, ParserMessage
 from bluetti_mqtt.commands import QueryRangeCommand
 from bluetti_mqtt.devices import BluettiDevice, AC200M, AC300, EP500, EP500P, EB3A
 from bluetti_mqtt.bluetooth.client import BluetoothClient
-from bluetti_mqtt.bluetooth.exc import BadConnectionError, ParseError
+from bluetti_mqtt.bluetooth.exc import BadConnectionError, InvalidRequestError, ParseError
 
 
 DEVICE_NAME_RE = re.compile(r'^(AC200M|AC300|EP500P|EP500|EB3A)(\d+)$')
@@ -97,6 +97,8 @@ class BluetoothClientHandler:
             await self.bus.put(ParserMessage(device, parsed))
         except ParseError:
             logging.debug('Got a parse exception...')
+        except InvalidRequestError:
+            logging.debug(f'Got an invalid request error for {command}: {err}')
         except (BadConnectionError, BleakError) as err:
             logging.debug(f'Needed to disconnect due to error: {err}')
 

--- a/bluetti_mqtt/bluetooth/__init__.py
+++ b/bluetti_mqtt/bluetooth/__init__.py
@@ -38,7 +38,9 @@ class BluetoothClientHandler:
 
         # Poll the clients
         logging.info('Starting to poll clients...')
-        await asyncio.gather(*[self._poll(d, c) for d, c in self.clients.items()])
+        polling_tasks = [self._poll(d, c) for d, c in self.clients.items()]
+        pack_polling_tasks = [self._pack_poll(d, c) for d, c in self.clients.items() if len(d.pack_logging_commands) > 0]
+        await asyncio.gather(*(polling_tasks + pack_polling_tasks))
 
     async def handle_command(self, msg: CommandMessage):
         if msg.device in self.clients:
@@ -53,10 +55,34 @@ class BluetoothClientHandler:
                 await asyncio.sleep(1)
                 continue
 
+            # Send all polling commands
             start_time = time.monotonic()
-            await self._poll_with_command(device, client, QueryRangeCommand(0x00, 0x0A, 0x35))
-            await self._poll_with_command(device, client, QueryRangeCommand(0x00, 0x46, 0x42))
-            await self._poll_with_command(device, client, QueryRangeCommand(0x0B, 0xB9, 0x3D))
+            for command in device.polling_commands:
+                await self._poll_with_command(device, client, command)
+            elapsed = time.monotonic() - start_time
+
+            # Limit polling rate if interval provided
+            if self.interval > 0 and self.interval > elapsed:
+                await asyncio.sleep(self.interval - elapsed)
+
+    async def _pack_poll(self, device: BluettiDevice, client: BluetoothClient):
+        while True:
+            if not client.is_connected:
+                logging.debug(f'Waiting for connection to {device.address} to start pack polling...')
+                await asyncio.sleep(1)
+                continue
+
+            start_time = time.monotonic()
+            for pack in range(1, device.pack_num_max + 1):
+                # Send pack set command if the device supports more than 1 pack
+                if device.pack_num_max > 1:
+                    command = device.build_setter_command('pack_num', pack)
+                    await client.perform_nowait(command)
+                    await asyncio.sleep(10) # We need to wait after switching packs for the data to be available
+
+                # Poll
+                for command in device.pack_logging_commands:
+                    await self._poll_with_command(device, client, command)
             elapsed = time.monotonic() - start_time
 
             # Limit polling rate if interval provided

--- a/bluetti_mqtt/devices/ac200m.py
+++ b/bluetti_mqtt/devices/ac200m.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import List
+from bluetti_mqtt.commands import QueryRangeCommand
 from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
@@ -63,3 +65,30 @@ class AC200M(BluettiDevice):
         self.struct.add_enum_field('auto_sleep_mode', 0x0B, 0xF5, AutoSleepMode)
 
         super().__init__(address, 'AC200M', sn)
+
+    @property
+    def pack_num_max(self):
+        return 3
+
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x28),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_polling_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x25)]
+
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x00, 0x46),
+            QueryRangeCommand(0x00, 0x46, 0x15),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_logging_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x77)]

--- a/bluetti_mqtt/devices/ac300.py
+++ b/bluetti_mqtt/devices/ac300.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import List
+from bluetti_mqtt.commands import QueryRangeCommand
 from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
@@ -85,3 +87,30 @@ class AC300(BluettiDevice):
         self.struct.add_enum_field('auto_sleep_mode', 0x0B, 0xF5, AutoSleepMode)
 
         super().__init__(address, 'AC300', sn)
+
+    @property
+    def pack_num_max(self):
+        return 4
+
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x28),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_polling_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x25)]
+
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x00, 0x46),
+            QueryRangeCommand(0x00, 0x46, 0x15),
+            QueryRangeCommand(0x0B, 0xB8, 0x3E),
+        ]
+
+    @property
+    def pack_logging_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x77)]

--- a/bluetti_mqtt/devices/bluetti_device.py
+++ b/bluetti_mqtt/devices/bluetti_device.py
@@ -1,5 +1,5 @@
-from typing import Any
-from bluetti_mqtt.commands import UpdateFieldCommand
+from typing import Any, List
+from bluetti_mqtt.commands import QueryRangeCommand, UpdateFieldCommand
 from .struct import BoolField, DeviceStruct, EnumField
 
 
@@ -13,6 +13,35 @@ class BluettiDevice:
 
     def parse(self, page: int, offset: int, data: bytes) -> dict:
         return self.struct.parse(page, offset, data)
+
+    """
+    A given device has a maximum number of battery packs, including the
+    internal battery if it has one. We can provide this information statically
+    so it's not necessary to poll the device.
+    """
+    @property
+    def pack_num_max(self):
+        return 1
+
+    """A given device has an optimal set of commands for polling"""
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        raise NotImplementedError
+
+    """A given device may have a set of commands for polling pack data"""
+    @property
+    def pack_polling_commands(self) -> List[QueryRangeCommand]:
+        return []
+
+    """A given device has an optimal set of commands for debug logging"""
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        raise NotImplementedError
+
+    """A given device may have a set of commands for logging pack data"""
+    @property
+    def pack_logging_commands(self) -> List[QueryRangeCommand]:
+        return []
 
     def has_field_setter(self, field: str):
         return any(f.page == 0x0B and f.name == field for f in self.struct.fields)

--- a/bluetti_mqtt/devices/eb3a.py
+++ b/bluetti_mqtt/devices/eb3a.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import List
+from bluetti_mqtt.commands import QueryRangeCommand
 from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
@@ -18,6 +20,8 @@ class EB3A(BluettiDevice):
         # Page 0x00 - Core
         self.struct.add_string_field('device_type', 0x00, 0x0A, 6)
         self.struct.add_sn_field('serial_number', 0x00, 0x11)
+        self.struct.add_version_field('arm_version', 0x00, 0x17)
+        self.struct.add_version_field('dsp_version', 0x00, 0x19)
         self.struct.add_uint_field('dc_input_power', 0x00, 0x24)
         self.struct.add_uint_field('ac_input_power', 0x00, 0x25)
         self.struct.add_uint_field('ac_output_power', 0x00, 0x26)
@@ -40,3 +44,20 @@ class EB3A(BluettiDevice):
         self.struct.add_enum_field('led_mode', 0x0B, 0xDA, LedMode)
 
         super().__init__(address, 'EB3A', sn)
+
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x28),
+            QueryRangeCommand(0x00, 0x46, 0x15),
+            QueryRangeCommand(0x0B, 0xB9, 0x1C)
+        ]
+
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x35),
+            QueryRangeCommand(0x00, 0x46, 0x42),
+            QueryRangeCommand(0x00, 0x88, 0x4A),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D)
+        ]

--- a/bluetti_mqtt/devices/ep500.py
+++ b/bluetti_mqtt/devices/ep500.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import List
+from bluetti_mqtt.commands import QueryRangeCommand
 from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
@@ -84,3 +86,26 @@ class EP500(BluettiDevice):
         self.struct.add_enum_field('auto_sleep_mode', 0x0B, 0xF5, AutoSleepMode)
 
         super().__init__(address, 'EP500', sn)
+
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x28),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_polling_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x25)]
+
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x00, 0x46),
+            QueryRangeCommand(0x00, 0x46, 0x15),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_logging_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x77)]

--- a/bluetti_mqtt/devices/ep500p.py
+++ b/bluetti_mqtt/devices/ep500p.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import List
+from bluetti_mqtt.commands import QueryRangeCommand
 from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
@@ -84,3 +86,26 @@ class EP500P(BluettiDevice):
         self.struct.add_enum_field('auto_sleep_mode', 0x0B, 0xF5, AutoSleepMode)
 
         super().__init__(address, 'EP500P', sn)
+
+    @property
+    def polling_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x0A, 0x28),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_polling_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x25)]
+
+    @property
+    def logging_commands(self) -> List[QueryRangeCommand]:
+        return [
+            QueryRangeCommand(0x00, 0x00, 0x46),
+            QueryRangeCommand(0x00, 0x46, 0x15),
+            QueryRangeCommand(0x0B, 0xB9, 0x3D),
+        ]
+
+    @property
+    def pack_logging_commands(self) -> List[QueryRangeCommand]:
+        return [QueryRangeCommand(0x00, 0x5B, 0x77)]


### PR DESCRIPTION
Adds API for configurable device-specific polling behavior (optimized separately from logging), as well as parallel pack and non-pack data polling loops.

Fixes #4 