### PR TITLE
expose led to homeassistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## FUTURE
 
-* Add LED status and setting to homeassistant for EB3A
+* Add LED status and setting to homeassistant for EB3A (@ray0711)
 
 ## 0.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Add LED status and setting to homeassistant for EB3A
+
 ## 0.8.3
 
 * Fix a bug with `dc_input_power` reporting

--- a/bluetti_mqtt/core/devices/eb3a.py
+++ b/bluetti_mqtt/core/devices/eb3a.py
@@ -50,7 +50,7 @@ class EB3A(BluettiDevice):
         return [
             QueryRangeCommand(0x00, 0x0A, 0x28),
             QueryRangeCommand(0x00, 0x46, 0x15),
-            QueryRangeCommand(0x0B, 0xB9, 0x1C)
+            QueryRangeCommand(0x0B, 0xB9, 0x3D)
         ]
 
     @property

--- a/bluetti_mqtt/core/devices/eb3a.py
+++ b/bluetti_mqtt/core/devices/eb3a.py
@@ -50,7 +50,7 @@ class EB3A(BluettiDevice):
         return [
             QueryRangeCommand(0x00, 0x0A, 0x28),
             QueryRangeCommand(0x00, 0x46, 0x15),
-            QueryRangeCommand(0x0B, 0xB9, 0x3D)
+            QueryRangeCommand(0x0B, 0xDA, 1)
         ]
 
     @property
@@ -61,3 +61,4 @@ class EB3A(BluettiDevice):
             QueryRangeCommand(0x00, 0x88, 0x4A),
             QueryRangeCommand(0x0B, 0xB9, 0x3D)
         ]
+

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -217,7 +217,6 @@ class MQTTClient:
                                 device=d,
                                 name='LED Mode',
                                 icon='mdi:lightbulb',
-                                value_template= r'{{ value_json.power_on_behavior }}',
                                 options= [ 'LOW', 'HIGH', 'SOS', 'OFF' ],
                                 force_update=True)
                             .encode(),

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -210,18 +210,19 @@ class MQTTClient:
                             .encode(),
                         retain=True
                         )
-            await client.publish(f'homeassistant/select/{d.sn}_led_mode/config',
-                        payload=payload(
-                            id='led_mode',
-                            device=d,
-                            name='LED Mode',
-                            icon='mdi:lightbulb',
-                            value_template= r'{{ value_json.power_on_behavior }}',
-                            options= [ 'LOW', 'HIGH', 'SOS', 'OFF' ],
-                            force_update=True)
-                        .encode(),
-                        retain=True
-                        )
+            if d.has_field_setter('led_mode'):
+                await client.publish(f'homeassistant/select/{d.sn}_led_mode/config',
+                            payload=payload(
+                                id='led_mode',
+                                device=d,
+                                name='LED Mode',
+                                icon='mdi:lightbulb',
+                                value_template= r'{{ value_json.power_on_behavior }}',
+                                options= [ 'LOW', 'HIGH', 'SOS', 'OFF' ],
+                                force_update=True)
+                            .encode(),
+                            retain=True
+                            )
             logging.info(f'Sent discovery message of {d.type}-{d.sn} to Home Assistant')
 
 

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -210,7 +210,18 @@ class MQTTClient:
                             .encode(),
                         retain=True
                         )
-
+            await client.publish(f'homeassistant/select/{d.sn}_led_mode/config',
+                        payload=payload(
+                            id='led_mode',
+                            device=d,
+                            name='LED Mode',
+                            icon='mdi:lightbulb',
+                            value_template= r'{{ value_json.power_on_behavior }}',
+                            options= [ 'LOW', 'HIGH', 'SOS', 'OFF' ],
+                            force_update=True)
+                        .encode(),
+                        retain=True
+                        )
             logging.info(f'Sent discovery message of {d.type}-{d.sn} to Home Assistant')
 
 


### PR DESCRIPTION
adds status and control for the led to home assistant:

Open Issues
- not sure about the QueryRange if that is the right size, it works but might be too large? How is that calculated?
- the led is announced for all devices, looks like there is no good device specific anouncement yet?