### PR TITLE
Fix decimal conversion factors for DC inputs on the AC200Max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Fix decimal conversion factors for DC inputs on the AC200Max
+
 ## 0.9.0
 
 * Add LED status and setting to homeassistant for EB3A (@ray0711)

--- a/bluetti_mqtt/core/devices/ac200m.py
+++ b/bluetti_mqtt/core/devices/ac200m.py
@@ -46,9 +46,9 @@ class AC200M(BluettiDevice):
         self.struct.add_decimal_field('internal_current_one', 0x00, 0x48, 1)
         self.struct.add_uint_field('internal_power_one', 0x00, 0x49)
         self.struct.add_decimal_field('internal_ac_frequency', 0x00, 0x4A, 1)
-        self.struct.add_decimal_field('internal_dc_input_voltage', 0x00, 0x56, 1)
-        self.struct.add_uint_field('internal_dc_input_power', 0x00, 0x57)
-        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1)
+        self.struct.add_uint_field('internal_dc_input_voltage', 0x00, 0x56)
+        self.struct.add_decimal_field('internal_dc_input_power', 0x00, 0x57, 1)
+        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 2)
 
         # Page 0x00 - Battery Data
         self.struct.add_uint_field('pack_num_max', 0x00, 0x5B)


### PR DESCRIPTION
The AC200Max has slightly different decimal placements for the internal DC input fields than newer models. Going back through my reference data I have confirmed that these new conversion factors are correct. Fixes #32.