### PR TITLE
Re-write error handling to better log issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update AC500 support
 * Add split phase parsing support
 * Remove unsupported power_generation field from EB3A
+* Improved error reporting
 
 ## 0.9.2
 

--- a/bluetti_mqtt/bluetooth/client.py
+++ b/bluetti_mqtt/bluetooth/client.py
@@ -38,9 +38,11 @@ class BluetoothClient:
             # Try to connect
             try:
                 await self.client.connect()
-            except BaseException as err:
-                logging.error(f'Error connecting to device: {err}')
+                logging.info(f'Connected to device: {self.address}')
+            except BaseException:
+                logging.exception(f'Error connecting to device {self.address}:')
                 await asyncio.sleep(1)
+                logging.info(f'Retrying connection to {self.address}')
                 continue
 
             # Register for notifications and run command loop
@@ -49,11 +51,11 @@ class BluetoothClient:
                     self.NOTIFY_UUID,
                     self._notification_handler)
                 await self._perform_commands(self.client)
-            except (BleakError, asyncio.TimeoutError) as err:
-                logging.error(f'Reconnecting after error: {err}')
+            except (BleakError, asyncio.TimeoutError):
+                logging.exception(f'Reconnecting to {self.address} after error:')
                 continue
-            except BadConnectionError as err:
-                logging.error(f'Delayed reconnect after error: {err}')
+            except BadConnectionError:
+                logging.exception(f'Delayed reconnect to {self.address} after error:')
                 await asyncio.sleep(1)
             finally:
                 await self.client.disconnect()

--- a/bluetti_mqtt/device_handler.py
+++ b/bluetti_mqtt/device_handler.py
@@ -19,7 +19,7 @@ class DeviceHandler:
         loop = asyncio.get_running_loop()
 
         # Start manager
-        self.manager_task = loop.create_task(self.manager.run())
+        manager_task = loop.create_task(self.manager.run())
 
         # Connect to event bus
         self.bus.add_command_listener(self.handle_command)
@@ -28,7 +28,7 @@ class DeviceHandler:
         logging.info('Starting to poll clients...')
         polling_tasks = [self._poll(d) for d in self.manager.devices]
         pack_polling_tasks = [self._pack_poll(d) for d in self.manager.devices if len(d.pack_logging_commands) > 0]
-        await asyncio.gather(*(polling_tasks + pack_polling_tasks))
+        await asyncio.gather(*(polling_tasks + pack_polling_tasks + [manager_task]))
 
     async def handle_command(self, msg: CommandMessage):
         if self.manager.is_connected(msg.device):

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -71,8 +71,8 @@ class MQTTClient:
                         self._handle_commands(client),
                         self._handle_messages(client)
                     )
-            except MqttError as error:
-                logging.error(f'MQTT error: {error}')
+            except MqttError:
+                logging.exception('MQTT error:')
                 await asyncio.sleep(5)
 
     async def handle_message(self, msg: ParserMessage):


### PR DESCRIPTION
This addresses several concerns:
- Uncaught exceptions should now trigger an immediate shutdown, rather than a hang
- After a successful reconnect it now logs that it was successful
- Add timestamps to log lines for better debugging
- Switch from `logging.error` to `logging.exception` to get traceback logging