### PR TITLE
Add range limits to DC input current to filter out bad values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## FUTURE
 
 * Add a bluetti-discovery command that can collect information from unsupported Bluetti devices
+* Out-of-range DC input current values are no longer reported
 
 ## 0.11.1
 

--- a/bluetti_mqtt/core/devices/ac300.py
+++ b/bluetti_mqtt/core/devices/ac300.py
@@ -68,7 +68,7 @@ class AC300(BluettiDevice):
         self.struct.add_decimal_field('ac_input_frequency', 0x00, 0x50, 2)
         self.struct.add_decimal_field('internal_dc_input_voltage', 0x00, 0x56, 1)
         self.struct.add_uint_field('internal_dc_input_power', 0x00, 0x57)
-        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1)
+        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1, (0, 15))
 
         # Page 0x00 - Battery Data
         self.struct.add_uint_field('pack_num_max', 0x00, 0x5B)

--- a/bluetti_mqtt/core/devices/ep500.py
+++ b/bluetti_mqtt/core/devices/ep500.py
@@ -68,7 +68,7 @@ class EP500(BluettiDevice):
         self.struct.add_decimal_field('ac_input_frequency', 0x00, 0x50, 2)
         self.struct.add_decimal_field('internal_dc_input_voltage', 0x00, 0x56, 1)
         self.struct.add_uint_field('internal_dc_input_power', 0x00, 0x57)
-        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1)
+        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1, (0, 15))
 
         # Page 0x00 - Battery Data
         self.struct.add_uint_field('pack_num_max', 0x00, 0x5B)

--- a/bluetti_mqtt/core/devices/ep500p.py
+++ b/bluetti_mqtt/core/devices/ep500p.py
@@ -68,7 +68,7 @@ class EP500P(BluettiDevice):
         self.struct.add_decimal_field('ac_input_frequency', 0x00, 0x50, 2)
         self.struct.add_decimal_field('internal_dc_input_voltage', 0x00, 0x56, 1)
         self.struct.add_uint_field('internal_dc_input_power', 0x00, 0x57)
-        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1)
+        self.struct.add_decimal_field('internal_dc_input_current', 0x00, 0x58, 1, (0, 15))
 
         # Page 0x00 - Battery Data
         self.struct.add_uint_field('pack_num_max', 0x00, 0x5B)


### PR DESCRIPTION
Some times a value that is near the max of 65535 is reported for a given sensor, even though that couldn't possibly be a correct value. This functionality allows sensor reports like that to be filtered out of the reporting.

Fixes #62 