### PR TITLE
Limit internal_current_three on AC300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Out-of-range internal_current_three values are no longer reported for AC300
+
 ## 0.13.0
 
 * Add initial logging support for EP600 (and very basic polling)

--- a/bluetti_mqtt/core/devices/ac300.py
+++ b/bluetti_mqtt/core/devices/ac300.py
@@ -63,7 +63,7 @@ class AC300(BluettiDevice):
         self.struct.add_decimal_field('internal_current_two', 0x00, 0x4B, 1)
         self.struct.add_uint_field('internal_power_two', 0x00, 0x4C)
         self.struct.add_decimal_field('ac_input_voltage', 0x00, 0x4D, 1)
-        self.struct.add_decimal_field('internal_current_three', 0x00, 0x4E, 1)
+        self.struct.add_decimal_field('internal_current_three', 0x00, 0x4E, 1, (0, 100))
         self.struct.add_uint_field('internal_power_three', 0x00, 0x4F)
         self.struct.add_decimal_field('ac_input_frequency', 0x00, 0x50, 2)
         self.struct.add_decimal_field('internal_dc_input_voltage', 0x00, 0x56, 1)


### PR DESCRIPTION
When the inverter is on but grid charging is disabled, the AC300 frequently reports 6.5k for the measured current on `internal_current_three`. The AC300 is rated to 6000W (50A), but it doesn't hurt here to set the limit higher to 100A.