### PR TITLE
Configure additional battery fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE
 
+* Add additional battery pack details for AC200M, AC300, EP500(P), and AC500
+
 ## 0.14.0
 
 * BREAKING: The internal API has changed to better reflect standard MODBUS terminology

--- a/bluetti_mqtt/core/devices/ac200m.py
+++ b/bluetti_mqtt/core/devices/ac200m.py
@@ -52,6 +52,7 @@ class AC200M(BluettiDevice):
 
         # Battery Data
         self.struct.add_uint_field('pack_num_max', 91)
+        self.struct.add_decimal_field('total_battery_voltage', 92, 2)
         self.struct.add_uint_field('pack_num', 96)
         self.struct.add_decimal_field('pack_voltage', 98, 2)  # Full pack voltage
         self.struct.add_uint_field('pack_battery_percent', 99)

--- a/bluetti_mqtt/core/devices/ac300.py
+++ b/bluetti_mqtt/core/devices/ac300.py
@@ -15,6 +15,13 @@ class OutputMode(Enum):
 
 
 @unique
+class BatteryState(Enum):
+    STANDBY = 0
+    CHARGE = 1
+    DISCHARGE = 2
+
+
+@unique
 class UpsMode(Enum):
     CUSTOMIZED = 1
     PV_PRIORITY = 2
@@ -72,7 +79,10 @@ class AC300(BluettiDevice):
 
         # Battery Data
         self.struct.add_uint_field('pack_num_max', 91)
+        self.struct.add_decimal_field('total_battery_voltage', 92, 1)
+        self.struct.add_decimal_field('total_battery_current', 93, 1)
         self.struct.add_uint_field('pack_num', 96)
+        self.struct.add_enum_field('pack_status', 97, BatteryState)
         self.struct.add_decimal_field('pack_voltage', 98, 2)  # Full pack voltage
         self.struct.add_uint_field('pack_battery_percent', 99)
         self.struct.add_decimal_array_field('cell_voltages', 105, 16, 2)

--- a/bluetti_mqtt/core/devices/ac500.py
+++ b/bluetti_mqtt/core/devices/ac500.py
@@ -72,6 +72,7 @@ class AC500(BluettiDevice):
 
         # Battery Data
         self.struct.add_uint_field('pack_num_max', 91)
+        self.struct.add_decimal_field('total_battery_voltage', 92, 1)
         self.struct.add_uint_field('pack_num', 96)
         self.struct.add_decimal_field('pack_voltage', 98, 2)  # Full pack voltage
         self.struct.add_uint_field('pack_battery_percent', 99)

--- a/bluetti_mqtt/core/devices/ep500.py
+++ b/bluetti_mqtt/core/devices/ep500.py
@@ -72,6 +72,7 @@ class EP500(BluettiDevice):
 
         # Battery Data
         self.struct.add_uint_field('pack_num_max', 91)
+        self.struct.add_decimal_field('total_battery_voltage', 92, 1)
         self.struct.add_decimal_field('pack_voltage', 92, 1)  # Full pack voltage
         self.struct.add_uint_field('pack_battery_percent', 94)
         self.struct.add_uint_field('pack_num', 96)

--- a/bluetti_mqtt/core/devices/ep500p.py
+++ b/bluetti_mqtt/core/devices/ep500p.py
@@ -72,6 +72,7 @@ class EP500P(BluettiDevice):
 
         # Battery Data
         self.struct.add_uint_field('pack_num_max', 91)
+        self.struct.add_decimal_field('total_battery_voltage', 92, 1)
         self.struct.add_decimal_field('pack_voltage', 92, 1)  # Full pack voltage
         self.struct.add_uint_field('pack_battery_percent', 94)
         self.struct.add_uint_field('pack_num', 96)


### PR DESCRIPTION
This adds a few extra fields in the 91-105 range based on some reverse engineering on the AC300. A couple fields in that range are duplicates, so they have been excluded from parsing.