### PR TITLE
Basic AC60 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## FUTURE
 
 * Add additional battery pack details for AC200M, AC300, EP500(P), and AC500
+* Add initial logging support for AC60 (and very basic polling)
 
 ## 0.14.0
 

--- a/bluetti_mqtt/bluetooth/__init__.py
+++ b/bluetti_mqtt/bluetooth/__init__.py
@@ -3,13 +3,13 @@ import re
 from typing import Set
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
-from bluetti_mqtt.core import BluettiDevice, AC200M, AC300, AC500, EP500, EP500P, EP600, EB3A
+from bluetti_mqtt.core import BluettiDevice, AC200M, AC300, AC500, AC60, EP500, EP500P, EP600, EB3A
 from .client import BluetoothClient
 from .exc import BadConnectionError, ModbusError, ParseError
 from .manager import MultiDeviceManager
 
 
-DEVICE_NAME_RE = re.compile(r'^(AC200M|AC300|AC500|EP500P|EP500|EP600|EB3A)(\d+)$')
+DEVICE_NAME_RE = re.compile(r'^(AC200M|AC300|AC500|AC60|EP500P|EP500|EP600|EB3A)(\d+)$')
 
 
 async def scan_devices():
@@ -31,6 +31,8 @@ def build_device(address: str, name: str):
         return AC300(address, match[2])
     if match[1] == 'AC500':
         return AC500(address, match[2])
+    if match[1] == 'AC60':
+        return AC60(address, match[2])
     if match[1] == 'EP500':
         return EP500(address, match[2])
     if match[1] == 'EP500P':

--- a/bluetti_mqtt/core/__init__.py
+++ b/bluetti_mqtt/core/__init__.py
@@ -2,6 +2,7 @@ from .devices.bluetti_device import BluettiDevice
 from .devices.ac200m import AC200M
 from .devices.ac300 import AC300
 from .devices.ac500 import AC500
+from .devices.ac60 import AC60
 from .devices.ep500 import EP500
 from .devices.ep500p import EP500P
 from .devices.ep600 import EP600

--- a/bluetti_mqtt/core/devices/ac60.py
+++ b/bluetti_mqtt/core/devices/ac60.py
@@ -4,7 +4,7 @@ from .bluetti_device import BluettiDevice
 from .struct import DeviceStruct
 
 
-class EP600(BluettiDevice):
+class AC60(BluettiDevice):
     def __init__(self, address: str, sn: str):
         self.struct = DeviceStruct()
 
@@ -15,27 +15,16 @@ class EP600(BluettiDevice):
         self.struct.add_swap_string_field('device_type', 1101, 6)
         self.struct.add_sn_field('serial_number', 1107)
         self.struct.add_decimal_field('power_generation', 1202, 1)  # Total power generated since last reset (kwh)
-        # 2001-2003 is the current device time & date without a timezone
-        self.struct.add_uint_field('battery_range_start', 2022)
-        self.struct.add_uint_field('battery_range_end', 2023)
-        self.struct.add_uint_field('max_ac_input_power', 2213)
-        self.struct.add_uint_field('max_ac_input_current', 2214)
-        self.struct.add_uint_field('max_ac_output_power', 2215)
-        self.struct.add_uint_field('max_ac_output_current', 2216)
         self.struct.add_swap_string_field('battery_type', 6101, 6)
         self.struct.add_sn_field('battery_serial_number', 6107)
         self.struct.add_version_field('bcu_version', 6175)
-        self.struct.add_version_field('bmu_version', 6178)
-        self.struct.add_version_field('safety_module_version', 6181)
-        self.struct.add_version_field('high_voltage_module_version', 6184)
 
-        super().__init__(address, 'EP600', sn)
+        super().__init__(address, 'AC60', sn)
 
     @property
     def polling_commands(self) -> List[ReadHoldingRegisters]:
         return [
             ReadHoldingRegisters(100, 62),
-            ReadHoldingRegisters(2022, 2),
         ]
 
     @property
@@ -47,10 +36,9 @@ class EP600(BluettiDevice):
             ReadHoldingRegisters(1300, 31),
             ReadHoldingRegisters(1400, 48),
             ReadHoldingRegisters(1500, 30),
-            ReadHoldingRegisters(2000, 89),
-            ReadHoldingRegisters(2200, 41),
-            ReadHoldingRegisters(2300, 36),
-            ReadHoldingRegisters(6000, 32),
+            ReadHoldingRegisters(2000, 67),
+            ReadHoldingRegisters(2200, 29),
+            ReadHoldingRegisters(6000, 31),
             ReadHoldingRegisters(6100, 100),
-            ReadHoldingRegisters(6300, 100),
+            ReadHoldingRegisters(6300, 52),
         ]


### PR DESCRIPTION
Using discovery logs provided by @bxm6306, I was able to determine the appropriate logging ranges for the AC60. A couple of the fields from the EP600 were copied over.