### PR TITLE
Update dependency for aiomqtt from asyncio-mqtt

### DIFF
--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 from typing import List, Optional
-from asyncio_mqtt import Client, MqttError
+from aiomqtt import Client, MqttError
 from paho.mqtt.client import MQTTMessage
 from bluetti_mqtt.bus import CommandMessage, EventBus, ParserMessage
 from bluetti_mqtt.core import BluettiDevice, DeviceCommand
@@ -535,10 +535,9 @@ class MQTTClient:
         await self.message_queue.put(msg)
 
     async def _handle_commands(self, client: Client):
-        async with client.filtered_messages('bluetti/command/#') as messages:
-            await client.subscribe('bluetti/command/#')
-            async for mqtt_message in messages:
-                await self._handle_command(mqtt_message)
+        await client.subscribe('bluetti/command/#')
+        async for mqtt_message in client.messages:
+            await self._handle_command(mqtt_message)
 
     async def _handle_messages(self, client: Client):
         while True:

--- a/bluetti_mqtt/mqtt_client.py
+++ b/bluetti_mqtt/mqtt_client.py
@@ -631,7 +631,7 @@ class MQTTClient:
 
     async def _handle_command(self, mqtt_message: MQTTMessage):
         # Parse the mqtt_message.topic
-        m = COMMAND_TOPIC_RE.match(mqtt_message.topic)
+        m = COMMAND_TOPIC_RE.match(str(mqtt_message.topic))
         if not m:
             logging.warn(f'unknown command topic: {mqtt_message.topic}')
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-asyncio-mqtt==0.12.1
-bleak==0.14.3
-crcmod==1.7
-dbus-next==0.2.3
-paho-mqtt==1.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >=3.7
 packages = find:
 zip_safe = false
 install_requires =
-    asyncio-mqtt
+    aiomqtt
     bleak
     crcmod
 


### PR DESCRIPTION
Update to use the renamed `aiomqtt`, now `asyncio-mqtt` and remove depreciated `filtered_messages` call.

Fixes #107 

References:

- https://sbtinstruments.github.io/aiomqtt/migration-guide-v2.html
- https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html